### PR TITLE
tela de gerenciar a administração feita

### DIFF
--- a/lojaDados/App.js
+++ b/lojaDados/App.js
@@ -9,12 +9,12 @@ import Login from "./src/screens/login";
 import Feed from "./src/screens/feed";
 import Register from "./src/screens/register";
 import Home from "./src/screens/home";
+import Adm from "./src/screens/adm";
+import MySessions from "./src/screens/mySessions";
+import GerenciarAdmins from "./src/screens/GerenciarAdmins";
 
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
-
-import Adm from "./src/screens/adm";
-import MySessions from "./src/screens/mySessions";
 
 const Stack = createStackNavigator();
 const Tabs = createBottomTabNavigator();
@@ -116,7 +116,21 @@ export default function App() {
               borderBottomWidth: 0,
             },
             headerTintColor: "#FF0068",
-            headerTitle: "Login",
+            headerTitle: "Adm",
+          }}
+        />
+        <Stack.Screen
+          name="GerenciarAdmins"
+          component={GerenciarAdmins}
+          options={{
+            headerStyle: {
+              backgroundColor: "#000000",
+              borderBottomColor: "#FF0068",
+              borderBottomWidth: 1,
+              borderBottomWidth: 0,
+            },
+            headerTintColor: "#FF0068",
+            headerTitle: "Portal",
           }}
         />
         <Stack.Screen

--- a/lojaDados/app.json
+++ b/lojaDados/app.json
@@ -4,26 +4,23 @@
     "slug": "lojaDados",
     "version": "1.0.0",
     "orientation": "portrait",
-    "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "newArchEnabled": true,
     "splash": {
-      "image": "./assets/splash-icon.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
+    "plugins": ["expo-dev-client"],
     "ios": {
       "supportsTablet": true
     },
     "android": {
       "adaptiveIcon": {
-        "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "edgeToEdgeEnabled": true
+      "edgeToEdgeEnabled": true,
+      "package": "com.anonymous.lojaDados"
     },
-    "web": {
-      "favicon": "./assets/favicon.png"
-    }
+    "web": {}
   }
 }

--- a/lojaDados/package-lock.json
+++ b/lojaDados/package-lock.json
@@ -14,8 +14,9 @@
         "@react-navigation/native-stack": "^7.3.14",
         "@react-navigation/stack": "^7.3.3",
         "expo": "~53.0.9",
+        "expo-dev-client": "~5.2.1",
         "expo-status-bar": "~2.2.3",
-        "firebase": "^11.8.1",
+        "firebase": "^11.9.1",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.2",
@@ -1978,9 +1979,9 @@
       }
     },
     "node_modules/@firebase/ai": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-1.3.0.tgz",
-      "integrity": "sha512-qBxJTtl9hpgZr050kVFTRADX6I0Ss6mEQyp/JEkBgKwwxixKnaRNqEDGFba4OKNL7K8E4Y7LlA/ZW6L8aCKH4A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-1.4.0.tgz",
+      "integrity": "sha512-wvF33gtU6TXb6Co8TEC1pcl4dnVstYmRE/vs9XjUGE7he7Sgf5TqSu+EoXk/fuzhw5tKr1LC5eG9KdYFM+eosw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
@@ -2036,9 +2037,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.13.0.tgz",
-      "integrity": "sha512-Vj3MST245nq+V5UmmfEkB3isIgPouyUr8yGJlFeL9Trg/umG5ogAvrjAYvQ8gV7daKDoQSRnJKWI2JFpQqRsuQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.13.1.tgz",
+      "integrity": "sha512-0O33PKrXLoIWkoOO5ByFaLjZehBctSYWnb+xJkIdx2SKP/K9l1UPFXPwASyrOIqyY3ws+7orF/1j7wI5EKzPYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
@@ -2102,12 +2103,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.4.0.tgz",
-      "integrity": "sha512-LjLUrzbUgTa/sCtPoLKT2C7KShvLVHS3crnU1Du02YxnGVLE0CUBGY/NxgfR/Zg84mEbj1q08/dgesojxjn0dA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.4.1.tgz",
+      "integrity": "sha512-9VGjnY23Gc1XryoF/ABWtZVJYnaPOnjHM7dsqq9YALgKRtxI1FryvELUVkDaEIUf4In2bfkb9ZENF1S9M273Dw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app": "0.13.0",
+        "@firebase/app": "0.13.1",
         "@firebase/component": "0.6.17",
         "@firebase/logger": "0.4.4",
         "@firebase/util": "1.12.0",
@@ -2124,9 +2125,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.6.tgz",
-      "integrity": "sha512-cFbo2FymQltog4atI9cKTO6CxKxS0dOMXslTQrlNZRH7qhDG44/d7QeI6GXLweFZtrnlecf52ESnNz1DU6ek8w==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.7.tgz",
+      "integrity": "sha512-77o0aBKCfchdL1gkahARdawHyYefh+wRYn7o60tbwW6bfJNq2idbrRb3WSYCT4yBKWL0+9kKdwxBHPZ6DEiB+g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
@@ -2148,12 +2149,12 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.5.26",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.26.tgz",
-      "integrity": "sha512-4baB7tR0KukyGzrlD25aeO4t0ChLifwvDQXTBiVJE9WWwJEOjkZpHmoU9Iww0+Vdalsq4sZ3abp6YTNjHyB1dA==",
+      "version": "0.5.27",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.27.tgz",
+      "integrity": "sha512-axZx/MgjNO7uPA8/nMQiuVotGCngUFMppt5w0pxFIoIPD0kac0bsFdSEh5S2ttuEE0Aq1iUB6Flzwn+wvMgXnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth": "1.10.6",
+        "@firebase/auth": "1.10.7",
         "@firebase/auth-types": "0.13.0",
         "@firebase/component": "0.6.17",
         "@firebase/util": "1.12.0",
@@ -2257,9 +2258,9 @@
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.7.16",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.16.tgz",
-      "integrity": "sha512-5OpvlwYVUTLEnqewOlXmtIpH8t2ISlZHDW0NDbKROM2D0ATMqFkMHdvl+/wz9zOAcb8GMQYlhCihOnVAliUbpQ==",
+      "version": "4.7.17",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.17.tgz",
+      "integrity": "sha512-YhXWA7HlSnekExhZ5u4i0e+kpPxsh/qMrzeNDgsAva71JXK8OOuOx+yLyYBFhmu3Hr5JJDO2fsZA/wrWoQYHDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
@@ -2278,13 +2279,13 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.51",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.51.tgz",
-      "integrity": "sha512-E5iubPhS6aAM7oSsHMx/FGBwfA2nbEHaK/hCs+MD3l3N7rHKnq4SYCGmVu/AraSJaMndZR1I37N9A/BH7aCq5A==",
+      "version": "0.3.52",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.52.tgz",
+      "integrity": "sha512-nzt3Sag+EBdm1Jkw/FnnKBPk0LpUUxOlMHMADPBXYhhXrLszxn1+vb64nJsbgRIHfsCn+rg8gyGrb+8frzXrjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
-        "@firebase/firestore": "4.7.16",
+        "@firebase/firestore": "4.7.17",
         "@firebase/firestore-types": "3.0.3",
         "@firebase/util": "1.12.0",
         "tslib": "^2.1.0"
@@ -2521,9 +2522,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/storage": {
-      "version": "0.13.12",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.12.tgz",
-      "integrity": "sha512-5JmoFS01MYjW1XMQa5F5rD/kvMwBN10QF03bmcuJWq4lg+BJ3nRgL3sscWnyJPhwM/ZCyv2eRwcfzESVmsYkdQ==",
+      "version": "0.13.13",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.13.tgz",
+      "integrity": "sha512-E+MTNcBgpoAynicgVb2ZsHCuEOO4aAiUX5ahNwe/1dEyZpo2H4DwFqKQRNK/sdAIgBbjBwcfV2p0MdPFGIR0Ew==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
@@ -2538,13 +2539,13 @@
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.22.tgz",
-      "integrity": "sha512-29j6JgXTjQ76sOIkxmTNHQfYA/hDTeV9qGbn0jolynPXSg/AmzCB0CpCoCYrS0ja0Flgmy1hkA3XYDZ/eiV1Cg==",
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.23.tgz",
+      "integrity": "sha512-B/ufkT/R/tSvc2av+vP6ZYybGn26FwB9YVDYg/6Bro+5TN3VEkCeNmfnX3XLa2DSdXUTZAdWCbMxW0povGa4MA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.6.17",
-        "@firebase/storage": "0.13.12",
+        "@firebase/storage": "0.13.13",
         "@firebase/storage-types": "0.8.3",
         "@firebase/util": "1.12.0",
         "tslib": "^2.1.0"
@@ -3645,6 +3646,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/anser": {
@@ -4913,6 +4930,58 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-dev-client": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-5.2.1.tgz",
+      "integrity": "sha512-SzrHvXeyTGawzc/7ZIHFmaUYiCeRJagL9bJo/yTPmxdycFFOOdLs1FNMFXyYhB6YY4u5EKTCO6g1fug+0GV9sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "5.1.13",
+        "expo-dev-menu": "6.1.12",
+        "expo-dev-menu-interface": "1.10.0",
+        "expo-manifests": "~0.16.5",
+        "expo-updates-interface": "~1.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "5.1.13",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-5.1.13.tgz",
+      "integrity": "sha512-EAxkI0MOZk1E9tkk+QpyDhqlCjUqAr8q+mobcC3ZJIIi7KejhaQlGVlF1kUUITsYLvFvbT8egRgrsMO57T6uDA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.11.0",
+        "expo-dev-menu": "6.1.12",
+        "expo-manifests": "~0.16.5",
+        "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-6.1.12.tgz",
+      "integrity": "sha512-Bz8yjZ6a+u7ZrZWzfn3aCgBwAX+QB0ktQyV7QMS5/agyesKiqM43+VdwNQqrm8w9tS8HZ2sf6RTvdek8YgOEHg==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "1.10.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-1.10.0.tgz",
+      "integrity": "sha512-NxtM/qot5Rh2cY333iOE87dDg1S8CibW+Wu4WdLua3UMjy81pXYzAGCZGNOeY7k9GpNFqDPNDXWyBSlk9r2pBg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-file-system": {
       "version": "18.1.10",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.10.tgz",
@@ -4936,6 +5005,12 @@
         "react": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "14.1.4",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-14.1.4.tgz",
@@ -4944,6 +5019,19 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.16.5.tgz",
+      "integrity": "sha512-zLUeJogn2C7qOE75Zz7jcmJorMfIbSRR35ctspN0OK/Hq/+PAAptA8p9jNVC8xp/91uP9uI8f3xPhh+A11eR2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~11.0.10",
+        "expo-json-utils": "~0.15.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -4985,6 +5073,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-1.1.0.tgz",
+      "integrity": "sha512-DeB+fRe0hUDPZhpJ4X4bFMAItatFBUPjw/TVSbJsaf3Exeami+2qbbJhWkcTMoYHOB73nOIcaYcWXYJnCJXO0w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/exponential-backoff": {
@@ -5127,26 +5224,26 @@
       }
     },
     "node_modules/firebase": {
-      "version": "11.8.1",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.8.1.tgz",
-      "integrity": "sha512-oetXhPCvJZM4DVL/n/06442emMU+KzM0JLZjszpwlU6mqdFZqBwumBxn6hQkLukJyU5wsjihZHUY8HEAE2micg==",
+      "version": "11.9.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.9.1.tgz",
+      "integrity": "sha512-nbQbQxNlkHHRDn4cYwHdAKHwJPeZ0jRXxlNp6PCOb9CQx8Dc6Vjve97R34r1EZJnzOsPYZ3+ssJH7fkovDjvCw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/ai": "1.3.0",
+        "@firebase/ai": "1.4.0",
         "@firebase/analytics": "0.10.16",
         "@firebase/analytics-compat": "0.2.22",
-        "@firebase/app": "0.13.0",
+        "@firebase/app": "0.13.1",
         "@firebase/app-check": "0.10.0",
         "@firebase/app-check-compat": "0.3.25",
-        "@firebase/app-compat": "0.4.0",
+        "@firebase/app-compat": "0.4.1",
         "@firebase/app-types": "0.9.3",
-        "@firebase/auth": "1.10.6",
-        "@firebase/auth-compat": "0.5.26",
+        "@firebase/auth": "1.10.7",
+        "@firebase/auth-compat": "0.5.27",
         "@firebase/data-connect": "0.3.9",
         "@firebase/database": "1.0.19",
         "@firebase/database-compat": "2.0.10",
-        "@firebase/firestore": "4.7.16",
-        "@firebase/firestore-compat": "0.3.51",
+        "@firebase/firestore": "4.7.17",
+        "@firebase/firestore-compat": "0.3.52",
         "@firebase/functions": "0.12.8",
         "@firebase/functions-compat": "0.3.25",
         "@firebase/installations": "0.6.17",
@@ -5157,8 +5254,8 @@
         "@firebase/performance-compat": "0.2.19",
         "@firebase/remote-config": "0.6.4",
         "@firebase/remote-config-compat": "0.2.17",
-        "@firebase/storage": "0.13.12",
-        "@firebase/storage-compat": "0.3.22",
+        "@firebase/storage": "0.13.13",
+        "@firebase/storage-compat": "0.3.23",
         "@firebase/util": "1.12.0"
       }
     },
@@ -5889,6 +5986,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -9083,6 +9186,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/use-latest-callback": {

--- a/lojaDados/package.json
+++ b/lojaDados/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web"
   },
   "dependencies": {
@@ -16,15 +16,16 @@
     "@react-navigation/stack": "^7.3.3",
     "expo": "~53.0.9",
     "expo-status-bar": "~2.2.3",
-    "firebase": "^11.8.1",
+    "firebase": "^11.9.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.2",
     "react-native-gesture-handler": "~2.24.0",
+    "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "^0.20.0",
-    "react-native-reanimated": "~3.17.4"
+    "expo-dev-client": "~5.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/lojaDados/src/screens/GerenciarAdmins.jsx
+++ b/lojaDados/src/screens/GerenciarAdmins.jsx
@@ -1,0 +1,145 @@
+// Tela de gerenciamento de administradores usando Firestore
+
+import React, { useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+} from "react-native";
+import {
+  getDocs,
+  collection,
+  setDoc,
+  deleteDoc,
+  doc,
+  getDoc,
+} from "firebase/firestore";
+import { db } from "../services/firebase";
+
+export default function AdminPanel() {
+  const [usuarios, setUsuarios] = useState([]);
+  const [search, setSearch] = useState("");
+  const [admins, setAdmins] = useState([]);
+
+  const fetchUsuarios = async () => {
+    const querySnapshot = await getDocs(collection(db, "users"));
+    const lista = querySnapshot.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    }));
+    setUsuarios(lista);
+  };
+
+  const fetchAdmins = async () => {
+    const snapshot = await getDocs(collection(db, "administradores"));
+    const lista = snapshot.docs.map((doc) => doc.id); // apenas os UIDs
+    setAdmins(lista);
+  };
+
+  const tornarAdmin = async (uid) => {
+    await setDoc(doc(db, "administradores", uid), { uid });
+    fetchAdmins();
+  };
+
+  const removerAdmin = async (uid) => {
+    await deleteDoc(doc(db, "administradores", uid));
+    fetchAdmins();
+  };
+
+  useEffect(() => {
+    fetchUsuarios();
+    fetchAdmins();
+  }, []);
+
+  const usuariosFiltrados = usuarios.filter((user) =>
+    user.email.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <ScrollView style={styles.container}>
+      <Text style={styles.title}>Gerenciar Administradores</Text>
+
+      <TextInput
+        placeholder="Buscar por email"
+        value={search}
+        onChangeText={setSearch}
+        style={styles.input}
+        placeholderTextColor="#888"
+      />
+
+      {usuariosFiltrados.map((user) => (
+        <View key={user.id} style={styles.userCard}>
+          <Text style={styles.email}>{user.email}</Text>
+          {admins.includes(user.id) ? (
+            <TouchableOpacity
+              style={styles.removerBtn}
+              onPress={() => removerAdmin(user.id)}
+            >
+              <Text style={styles.btnText}>Remover ADM</Text>
+            </TouchableOpacity>
+          ) : (
+            <TouchableOpacity
+              style={styles.tornarBtn}
+              onPress={() => tornarAdmin(user.id)}
+            >
+              <Text style={styles.btnText}>Tornar ADM</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: "#000",
+  },
+  title: {
+    color: "#FF0068",
+    fontSize: 24,
+    fontWeight: "bold",
+    marginBottom: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "#555",
+    padding: 8,
+    borderRadius: 6,
+    color: "#fff",
+    marginBottom: 16,
+  },
+  userCard: {
+    backgroundColor: "#111",
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: "#FF0068",
+  },
+  email: {
+    color: "#fff",
+    fontSize: 16,
+    marginBottom: 8,
+  },
+  tornarBtn: {
+    backgroundColor: "#00c853",
+    padding: 8,
+    borderRadius: 5,
+  },
+  removerBtn: {
+    backgroundColor: "#c62828",
+    padding: 8,
+    borderRadius: 5,
+  },
+  btnText: {
+    color: "#fff",
+    textAlign: "center",
+    fontWeight: "bold",
+  },
+});

--- a/lojaDados/src/screens/home.jsx
+++ b/lojaDados/src/screens/home.jsx
@@ -82,6 +82,14 @@ export default function Home({ navigation }) {
           />
         </View>
 
+        <View style={styles.divisionTopPage1}>
+          {uidAtual === adminUID && (
+            <TouchableOpacity onPress={() => navigation.navigate("GerenciarAdmins")}>
+              <Text style={styles.button}>Cadastrar novo Adm</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+
         <View style={styles.divisionTopPage1} />
       </View>
 


### PR DESCRIPTION
Introduces a new 'GerenciarAdmins' screen for managing admin users via Firestore, accessible from the home screen for the main admin. Updates the login flow to ensure users are registered in the 'users' collection upon first login. Also updates dependencies, adds expo-dev-client, and adjusts app configuration for Android package and plugins.